### PR TITLE
README.md: Fix F-Droid badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ArchWiki Viewer
 ===============
 A simple viewer for the Arch Linux Wiki. Page content is formatted for optimal mobile viewing.
 
-[<img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" alt="Get it on Google Play" height="80">](https://play.google.com/store/apps/details?id=com.jtmcn.archwiki.viewer) [<img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="80"><br/>](https://f-droid.org/repository/browse/?fdid=com.jtmcn.archwiki.viewer)
+[<img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" alt="Get it on Google Play" height="80">](https://play.google.com/store/apps/details?id=com.jtmcn.archwiki.viewer) [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="80"><br/>](https://f-droid.org/repository/browse/?fdid=com.jtmcn.archwiki.viewer)
 
 ## Screenshots
 


### PR DESCRIPTION
It seems the previous URL to the badge in
F-Droid's website is being redirected to its
GitLab repository. While the redirection works
in the web browser, it seems the rendering of
markdown in GitHub doesn't work. Changing to
the GitLab URL solves the issue.