### PR TITLE
Migrate to androidx

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,16 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
-
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.jtmcn.archwiki.viewer"
-        minSdkVersion 15
-        targetSdkVersion 25
+        minSdkVersion 21
+        targetSdkVersion 29
         versionCode 13
         versionName "1.0.12"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -20,20 +18,26 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.jakewharton:butterknife:8.6.0'
-    annotationProcessor 'com.jakewharton:butterknife-compiler:8.6.0'
 
-    compile 'com.google.code.gson:gson:2.7'
+    implementation 'com.jakewharton:butterknife:10.1.0'
+    annotationProcessor 'com.jakewharton:butterknife-compiler:10.1.0'
 
-    compile 'com.android.support:design:25.3.1'
-    compile 'com.android.support:support-v4:25.3.1'
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.google.code.gson:gson:2.8.2'
+
+    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
 }

--- a/app/src/main/java/com/github/takahirom/webview_in_coodinator_layout/NestedWebView.java
+++ b/app/src/main/java/com/github/takahirom/webview_in_coodinator_layout/NestedWebView.java
@@ -17,10 +17,10 @@
 package com.github.takahirom.webview_in_coodinator_layout;
 
 import android.content.Context;
-import android.support.v4.view.MotionEventCompat;
-import android.support.v4.view.NestedScrollingChild;
-import android.support.v4.view.NestedScrollingChildHelper;
-import android.support.v4.view.ViewCompat;
+import androidx.core.view.MotionEventCompat;
+import androidx.core.view.NestedScrollingChild;
+import androidx.core.view.NestedScrollingChildHelper;
+import androidx.core.view.ViewCompat;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.webkit.WebView;

--- a/app/src/main/java/com/github/takahirom/webview_in_coodinator_layout/NestedWebView.java
+++ b/app/src/main/java/com/github/takahirom/webview_in_coodinator_layout/NestedWebView.java
@@ -17,10 +17,12 @@
 package com.github.takahirom.webview_in_coodinator_layout;
 
 import android.content.Context;
+
 import androidx.core.view.MotionEventCompat;
 import androidx.core.view.NestedScrollingChild;
 import androidx.core.view.NestedScrollingChildHelper;
 import androidx.core.view.ViewCompat;
+
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.webkit.WebView;
@@ -120,7 +122,7 @@ public class NestedWebView extends WebView implements NestedScrollingChild {
 
 	@Override
 	public boolean dispatchNestedScroll(int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed,
-										int[] offsetInWindow) {
+	                                    int[] offsetInWindow) {
 		return mChildHelper.dispatchNestedScroll(dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed, offsetInWindow);
 	}
 

--- a/app/src/main/java/com/jtmcn/archwiki/viewer/MainActivity.java
+++ b/app/src/main/java/com/jtmcn/archwiki/viewer/MainActivity.java
@@ -4,11 +4,11 @@ import android.app.SearchManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v4.view.MenuItemCompat;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.SearchView;
-import android.support.v7.widget.ShareActionProvider;
-import android.support.v7.widget.Toolbar;
+import androidx.core.view.MenuItemCompat;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.SearchView;
+import androidx.appcompat.widget.ShareActionProvider;
+import androidx.appcompat.widget.Toolbar;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -47,7 +47,7 @@ public class MainActivity extends AppCompatActivity implements FetchUrl.OnFinish
 
 		setSupportActionBar(toolbar);
 
-		ProgressBar progressBar = ButterKnife.findById(this, R.id.progress_bar);
+		ProgressBar progressBar = findViewById(R.id.progress_bar);
 		wikiViewer.buildView(progressBar, getSupportActionBar());
 
 		handleIntent(getIntent());

--- a/app/src/main/java/com/jtmcn/archwiki/viewer/MainActivity.java
+++ b/app/src/main/java/com/jtmcn/archwiki/viewer/MainActivity.java
@@ -12,7 +12,6 @@ import androidx.appcompat.widget.Toolbar;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
 import android.webkit.WebSettings;
 import android.widget.ProgressBar;
 
@@ -113,12 +112,9 @@ public class MainActivity extends AppCompatActivity implements FetchUrl.OnFinish
 		SearchManager searchManager = (SearchManager) getSystemService(Context.SEARCH_SERVICE);
 		searchMenuItem = menu.findItem(R.id.menu_search);
 		searchView = (SearchView) MenuItemCompat.getActionView(searchMenuItem);
-		searchView.setOnQueryTextFocusChangeListener(new View.OnFocusChangeListener() {
-			@Override
-			public void onFocusChange(View v, boolean hasFocus) {
-				if (!hasFocus) {
-					hideSearchView();
-				}
+		searchView.setOnQueryTextFocusChangeListener((v, hasFocus) -> {
+			if (!hasFocus) {
+				hideSearchView();
 			}
 		});
 		searchView.setSearchableInfo(searchManager.getSearchableInfo(getComponentName()));
@@ -132,7 +128,7 @@ public class MainActivity extends AppCompatActivity implements FetchUrl.OnFinish
 			@Override
 			public boolean onQueryTextChange(String newText) {
 				if (newText.isEmpty()) {
-					setCursorAdapter(new ArrayList<SearchResult>());
+					setCursorAdapter(new ArrayList<>());
 					return true;
 				} else {
 					String searchUrl = SearchResultsBuilder.getSearchQuery(newText);
@@ -152,7 +148,7 @@ public class MainActivity extends AppCompatActivity implements FetchUrl.OnFinish
 			public boolean onSuggestionClick(int position) {
 				SearchResult searchResult = currentSuggestions.get(position);
 				Log.d(TAG, "Opening '" + searchResult.getPageName() + "' from search suggestion.");
-				wikiViewer.wikiClient.shouldOverrideUrlLoading(wikiViewer, searchResult.getPageUrl());
+				wikiViewer.wikiClient.shouldOverrideUrlLoading(wikiViewer, searchResult.getPageURL());
 				hideSearchView();
 				return true;
 			}

--- a/app/src/main/java/com/jtmcn/archwiki/viewer/PreferencesActivity.java
+++ b/app/src/main/java/com/jtmcn/archwiki/viewer/PreferencesActivity.java
@@ -30,7 +30,7 @@ public class PreferencesActivity extends AppCompatActivity {
 				.replace(R.id.settings_content, new ApplicationPreferenceFragment())
 				.commit();
 
-		Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+		Toolbar toolbar = findViewById(R.id.toolbar);
 		setSupportActionBar(toolbar);
 		setTitle(R.string.menu_settings);
 

--- a/app/src/main/java/com/jtmcn/archwiki/viewer/PreferencesActivity.java
+++ b/app/src/main/java/com/jtmcn/archwiki/viewer/PreferencesActivity.java
@@ -4,9 +4,9 @@ import android.os.Bundle;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
-import android.support.annotation.Nullable;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import android.view.MenuItem;
 
 /**

--- a/app/src/main/java/com/jtmcn/archwiki/viewer/SearchResultsAdapter.java
+++ b/app/src/main/java/com/jtmcn/archwiki/viewer/SearchResultsAdapter.java
@@ -4,8 +4,8 @@ import android.app.SearchManager;
 import android.content.Context;
 import android.database.MatrixCursor;
 import android.provider.BaseColumns;
-import android.support.v4.widget.CursorAdapter;
-import android.support.v4.widget.SimpleCursorAdapter;
+import androidx.cursoradapter.widget.CursorAdapter;
+import androidx.cursoradapter.widget.SimpleCursorAdapter;
 
 import com.jtmcn.archwiki.viewer.data.SearchResult;
 

--- a/app/src/main/java/com/jtmcn/archwiki/viewer/WikiClient.java
+++ b/app/src/main/java/com/jtmcn/archwiki/viewer/WikiClient.java
@@ -1,7 +1,7 @@
 package com.jtmcn.archwiki.viewer;
 
 import android.os.Handler;
-import android.support.v7.app.ActionBar;
+import androidx.appcompat.app.ActionBar;
 import android.util.Log;
 import android.view.View;
 import android.webkit.WebView;

--- a/app/src/main/java/com/jtmcn/archwiki/viewer/WikiView.java
+++ b/app/src/main/java/com/jtmcn/archwiki/viewer/WikiView.java
@@ -2,8 +2,8 @@ package com.jtmcn.archwiki.viewer;
 
 import android.content.Context;
 import android.os.Build;
-import android.support.v4.widget.SwipeRefreshLayout;
-import android.support.v7.app.ActionBar;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+import androidx.appcompat.app.ActionBar;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.KeyEvent;

--- a/app/src/main/java/com/jtmcn/archwiki/viewer/WikiView.java
+++ b/app/src/main/java/com/jtmcn/archwiki/viewer/WikiView.java
@@ -2,8 +2,10 @@ package com.jtmcn.archwiki.viewer;
 
 import android.content.Context;
 import android.os.Build;
+
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.appcompat.app.ActionBar;
+
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.KeyEvent;
@@ -19,12 +21,11 @@ import static com.jtmcn.archwiki.viewer.Constants.ARCHWIKI_SEARCH_URL;
 public class WikiView extends NestedWebView implements SwipeRefreshLayout.OnRefreshListener {
 	public static final String TAG = WikiView.class.getSimpleName();
 	WikiClient wikiClient;
-	private Context context;
 
 	public WikiView(Context context, AttributeSet attrs) {
 		super(context, attrs);
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && !isInEditMode()) {
-			//this allows the webview to inject the css (otherwise it blocks it for security reasons)
+			// This allows the webview to inject the css (otherwise it blocks it for security reasons)
 			getSettings().setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
 		}
 	}

--- a/app/src/main/java/com/jtmcn/archwiki/viewer/data/SearchResult.java
+++ b/app/src/main/java/com/jtmcn/archwiki/viewer/data/SearchResult.java
@@ -5,33 +5,30 @@ package com.jtmcn.archwiki.viewer.data;
  */
 public class SearchResult {
 	private final String pageName;
-	private final String pageUrl;
+	private final String pageURL;
 
 	/**
 	 * Create a search result.
 	 *
 	 * @param pageName the name of the page as shown on the wiki.
-	 * @param pageUrl  the string url on the wiki.
+	 * @param pageURL  the string url on the wiki.
 	 */
-	public SearchResult(String pageName, String pageUrl) {
+	public SearchResult(String pageName, String pageURL) {
 		this.pageName = pageName;
-		this.pageUrl = pageUrl;
+		this.pageURL = pageURL;
 	}
 
 	public String getPageName() {
 		return pageName;
 	}
 
-	public String getPageUrl() {
-		return pageUrl;
+	public String getPageURL() {
+		return pageURL;
 	}
 
 	@Override
 	public String toString() {
-		StringBuilder sb = new StringBuilder("SearchResult{");
-		sb.append("title='").append(pageName).append('\'');
-		sb.append(", url='").append(pageUrl).append('\'');
-		sb.append('}');
-		return sb.toString();
+		return "SearchResult{" + "title='" + pageName + '\'' +
+				", url='" + pageURL + '\'' + '}';
 	}
 }

--- a/app/src/main/java/com/jtmcn/archwiki/viewer/data/WikiPage.java
+++ b/app/src/main/java/com/jtmcn/archwiki/viewer/data/WikiPage.java
@@ -36,10 +36,7 @@ public class WikiPage {
 
 	@Override
 	public String toString() {
-		StringBuilder sb = new StringBuilder("WikiPage{");
-		sb.append("title='").append(pageTitle).append('\'');
-		sb.append('}');
-		return sb.toString();
+		return "WikiPage{" + "title='" + pageTitle + '\'' + '}';
 	}
 
 	public int getScrollPosition() {
@@ -58,7 +55,6 @@ public class WikiPage {
 		WikiPage wikiPage = (WikiPage) o;
 
 		return getPageUrl() != null ? getPageUrl().equals(wikiPage.getPageUrl()) : wikiPage.getPageUrl() == null;
-
 	}
 
 	@Override

--- a/app/src/main/java/com/jtmcn/archwiki/viewer/data/WikiPageBuilder.java
+++ b/app/src/main/java/com/jtmcn/archwiki/viewer/data/WikiPageBuilder.java
@@ -24,7 +24,7 @@ public class WikiPageBuilder {
 	 * Builds a page containing the title, url, and injects local css.
 	 *
 	 * @param stringUrl url to download.
-	 * @param html      stringbuilder containing the html of the wikipage
+	 * @param html      StringBuilder containing the html of the wikipage
 	 * @return {@link WikiPage} containing downloaded page.
 	 */
 	public static WikiPage buildPage(String stringUrl, StringBuilder html) {

--- a/app/src/main/java/com/jtmcn/archwiki/viewer/tasks/Fetch.java
+++ b/app/src/main/java/com/jtmcn/archwiki/viewer/tasks/Fetch.java
@@ -15,20 +15,10 @@ import java.util.List;
  */
 public class Fetch {
 	public static final FetchUrl.FetchUrlMapper<List<SearchResult>> SEARCH_RESULTS_MAPPER =
-			new FetchUrl.FetchUrlMapper<List<SearchResult>>() {
-				@Override
-				public List<SearchResult> mapTo(String url, StringBuilder stringBuilder) {
-					return SearchResultsBuilder.parseSearchResults(stringBuilder.toString());
-				}
-			};
+			(url, stringBuilder) -> SearchResultsBuilder.parseSearchResults(stringBuilder.toString());
 
-	public static final FetchUrl.FetchUrlMapper<WikiPage> WIKIPAGE_MAPPER =
-			new FetchUrl.FetchUrlMapper<WikiPage>() {
-				@Override
-				public WikiPage mapTo(String url, StringBuilder sb) {
-					return WikiPageBuilder.buildPage(url, sb);
-				}
-			};
+	public static final FetchUrl.FetchUrlMapper<WikiPage> WIKI_PAGE_MAPPER =
+			WikiPageBuilder::buildPage;
 
 	private Fetch() {
 
@@ -57,10 +47,9 @@ public class Fetch {
 	 */
 	public static AsyncTask<String, Void, WikiPage> page(
 			FetchUrl.OnFinish<WikiPage> onFinish,
-			String url,
-			boolean caching
+			String url
 	) {
-		return new FetchUrl<>(onFinish, WIKIPAGE_MAPPER).execute(url);
+		return new FetchUrl<>(onFinish, WIKI_PAGE_MAPPER).execute(url);
 	}
 
 }

--- a/app/src/main/java/com/jtmcn/archwiki/viewer/utils/AndroidUtils.java
+++ b/app/src/main/java/com/jtmcn/archwiki/viewer/utils/AndroidUtils.java
@@ -4,7 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.support.v4.app.ShareCompat;
+import androidx.core.app.ShareCompat;
 
 import com.jtmcn.archwiki.viewer.R;
 

--- a/app/src/main/java/com/jtmcn/archwiki/viewer/utils/NetworkUtils.java
+++ b/app/src/main/java/com/jtmcn/archwiki/viewer/utils/NetworkUtils.java
@@ -38,7 +38,7 @@ public class NetworkUtils {
 	 * @throws IOException on network failure.
 	 */
 	public static StringBuilder fetchURL(String stringUrl, boolean useCache) throws IOException {
-		StringBuilder sb = new StringBuilder("");
+		StringBuilder sb = new StringBuilder();
 		URL url = new URL(stringUrl);
 		if (useCache && downloadCache.containsKey(url)) {
 			return new StringBuilder(downloadCache.get(url));

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -16,4 +16,4 @@
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/toolbar.xml
+++ b/app/src/main/res/layout/toolbar.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.AppBarLayout
+<com.google.android.material.appbar.AppBarLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:theme="@style/AppTheme.AppBarOverlay">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -37,4 +37,4 @@
 
     </FrameLayout>
 
-</android.support.design.widget.AppBarLayout>
+</com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/menu/menu.xml
+++ b/app/src/main/res/menu/menu.xml
@@ -5,13 +5,13 @@
         android:id="@+id/menu_search"
         android:icon="@drawable/ic_search_white_24dp"
         android:title="@string/search"
-        app:actionViewClass="android.support.v7.widget.SearchView"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
         app:showAsAction="always|collapseActionView"/>
 
     <item
         android:id="@+id/menu_share"
         android:title="@string/share"
-        app:actionProviderClass="android.support.v7.widget.ShareActionProvider"/>
+        app:actionProviderClass="androidx.appcompat.widget.ShareActionProvider"/>
 
     <item
         android:id="@+id/refresh"

--- a/app/src/test/java/com/jtmcn/archwiki/viewer/data/SearchResultsBuilderTest.java
+++ b/app/src/test/java/com/jtmcn/archwiki/viewer/data/SearchResultsBuilderTest.java
@@ -1,8 +1,5 @@
 package com.jtmcn.archwiki.viewer.data;
 
-import com.jtmcn.archwiki.viewer.data.SearchResult;
-import com.jtmcn.archwiki.viewer.data.SearchResultsBuilder;
-
 import org.junit.Test;
 
 import java.util.List;
@@ -20,10 +17,10 @@ public class SearchResultsBuilderTest {
 		List<SearchResult> searchResults = SearchResultsBuilder.parseSearchResults(realResult);
 
 		assertEquals("Arch-based Distros",searchResults.get(0).getPageName());
-		assertEquals("https://wiki.archlinux.org/index.php/Arch-based_Distros", searchResults.get(0).getPageUrl());
+		assertEquals("https://wiki.archlinux.org/index.php/Arch-based_Distros", searchResults.get(0).getPageURL());
 
 		assertEquals("Arch-chroot",searchResults.get(2).getPageName());
-		assertEquals("https://wiki.archlinux.org/index.php/Arch-chroot", searchResults.get(2).getPageUrl());
+		assertEquals("https://wiki.archlinux.org/index.php/Arch-chroot", searchResults.get(2).getPageURL());
 	}
 
 	@Test

--- a/app/src/test/java/com/jtmcn/archwiki/viewer/data/WikiPageBuilderTest.java
+++ b/app/src/test/java/com/jtmcn/archwiki/viewer/data/WikiPageBuilderTest.java
@@ -8,11 +8,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-
 public class WikiPageBuilderTest {
 	@Test
 	public void getPageTitle() throws Exception {
-		String fakeTitle = " fake title..1!@#!@ #!RASDF";
+		String fakeTitle = "fake title..1!@#!@#!";
 		StringBuilder wrapped = new StringBuilder(WikiPageBuilder.HTML_TITLE_OPEN)
 				.append(fakeTitle)
 				.append(WikiPageBuilder.HTML_TITLE_CLOSE);
@@ -21,7 +20,7 @@ public class WikiPageBuilderTest {
 
 	@Test
 	public void getEmptyTitle() throws Exception {
-		assertEquals("No title found", WikiPageBuilder.getPageTitle(new StringBuilder("")));
+		assertEquals("No title found", WikiPageBuilder.getPageTitle(new StringBuilder()));
 	}
 
 	@Test

--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,22 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.4.2'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.enableJetifier=true
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 03 11:24:59 CDT 2017
+#Wed Jul 17 15:36:20 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
Migrated from [Support libraries](https://developer.android.com/topic/libraries/support-library/index) to [AndroidX libraries](https://developer.android.com/jetpack/androidx?gclid=Cj0KCQjwjrvpBRC0ARIsAFrFuV9y1lHzcOgR7mFgiF_Ov7XBXqUJXSzWLsecYO846luqglkK7FMzhZYaAg4WEALw_wcB) as part of [Jetpack suite](https://developer.android.com/jetpack). Going forward (bayond API level 28) development on Support libraries will stop.
Updated target Sdk to 29 (Q beta) and min Sdk to  21 which allows for faster build times.